### PR TITLE
Updated Compile configuration with Implementation and minor changes in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ The library is a DrawerLayout-like ViewGroup, where a "drawer" is hidden under t
 
 ![GifSample](art/sample.gif)
 
-## Gradle 
-Add this into your dependencies block.
+## Installation 
+Gradle is the only supported build configuration, so just add the dependency to your project ``Build.gradle`` file
 ```
-implementation 'com.yarolegovich:sliding-root-nav:1.1.1'
+dependencies {
+  implementation 'com.yarolegovich:sliding-root-nav:1.1.1'
+}
 ```
 ## Sample
 Please see the [sample app](sample/src/main/java/com/yarolegovich/slidingrootnav/sample) for a library usage example.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The library is a DrawerLayout-like ViewGroup, where a "drawer" is hidden under t
 ## Gradle 
 Add this into your dependencies block.
 ```
-compile 'com.yarolegovich:sliding-root-nav:1.1.1'
+implementation 'com.yarolegovich:sliding-root-nav:1.1.1'
 ```
 ## Sample
 Please see the [sample app](sample/src/main/java/com/yarolegovich/slidingrootnav/sample) for a library usage example.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The library is a DrawerLayout-like ViewGroup, where a "drawer" is hidden under t
 
 ## Installation 
 Gradle is the only supported build configuration, so just add the dependency to your project ``Build.gradle`` file
-```
+```java
 dependencies {
   implementation 'com.yarolegovich:sliding-root-nav:1.1.1'
 }


### PR DESCRIPTION
Hi Sir! Big Fan. Absolutely loved your great library and using it from a few days.

I have made few simple changes in READ.ME file regarding installation of dependency in ``Build.gradle`` , and replaced ``compile`` configuration by ``implementation`` and also highlighted the dependency for attractive view..

Sir as we know ,Compile time dependencies is superseded by implementation . The compile dependency configuration has been removed in the recently released Gradle 7.0, and is deprecated in earlier versions. Fortunately, the implementation dependency configuration provides the same functionality as compile.

Now we should always use implementation rather than compile for dependencies, as compile is now deprecated or removed in the case of Gradle 7+.Considering the above information, I made changes to replace compile with implementation
Thank you.